### PR TITLE
Take currency's decimal places into account when creating intent

### DIFF
--- a/src/Managers/StripeManager.php
+++ b/src/Managers/StripeManager.php
@@ -50,7 +50,7 @@ class StripeManager
         }
 
         $paymentIntent = $this->buildIntent(
-            $cart->total->value,
+            (int)round($cart->total->value * pow(10, 2 - $cart->currency->decimal_places)),
             $cart->currency->code,
             $shipping,
         );


### PR DESCRIPTION
It seems to me that the amount charged by Stripe is incorrect for currencies that don't use 2 decimal places.

E.g. when using 3 decimal places, Stripe will charge a 10-fold of your cart value.

This PR corrects this by taking into account the currency's decimal places when creating a payment intent.