### PR TITLE
Enforce Stripe API version

### DIFF
--- a/src/Managers/StripeManager.php
+++ b/src/Managers/StripeManager.php
@@ -13,6 +13,7 @@ class StripeManager
     public function __construct()
     {
         Stripe::setApiKey(config('services.stripe.key'));
+        Stripe::setApiVersion('2022-08-01');
     }
 
     /**
@@ -22,9 +23,10 @@ class StripeManager
      */
     public function getClient()
     {
-        return new StripeClient(
-            config('services.stripe.key')
-        );
+        return new StripeClient([
+            'api_key' => config('services.stripe.key'),
+            'stripe_version' => '2022-08-01'
+        ]);
     }
 
     /**


### PR DESCRIPTION
When installing the package sometimes the new Stripe API is used thus breaking how it works. To avoid that we enforce the use of the version it has been initially built on.